### PR TITLE
Fix declaration of '__all__' in top-level package.

### DIFF
--- a/pyset_x/__init__.py
+++ b/pyset_x/__init__.py
@@ -1,3 +1,3 @@
 from pyset_x.core import annotate_function
 
-__all__ == ['annotate_function']
+__all__ = ['annotate_function']


### PR DESCRIPTION
This should be a single equals sign, not double.